### PR TITLE
Fixed error when AWS account ID specified as Principal

### DIFF
--- a/lib/cfn-model/model/principal.rb
+++ b/lib/cfn-model/model/principal.rb
@@ -2,6 +2,8 @@ class Principal
   def self.wildcard?(principal)
     if principal.is_a? String
       return has_asterisk principal
+    elsif principal.is_a? Integer
+      return has_asterisk principal.to_s
     elsif principal.is_a? Hash
       # if new principal types arrive, let's not tie ourselves down - the * is still likely the thing to look for
       # unless %w(AWS FederatedUser CanonicalUser Service).include?(principal.keys.first)

--- a/lib/cfn-model/model/principal.rb
+++ b/lib/cfn-model/model/principal.rb
@@ -3,7 +3,7 @@ class Principal
     if principal.is_a? String
       return has_asterisk principal
     elsif principal.is_a? Integer
-      return has_asterisk principal.to_s
+      false
     elsif principal.is_a? Hash
       # if new principal types arrive, let's not tie ourselves down - the * is still likely the thing to look for
       # unless %w(AWS FederatedUser CanonicalUser Service).include?(principal.keys.first)


### PR DESCRIPTION
Principal class should not raise  "whacky principal not string or hash: #{principal}" when an AWS account ID is specified in the field Principal field