### PR TITLE
ImageId no longer required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-# Created by .ignore support plugin (hsz.mobi)
-
 .DS_Store
-
 /coverage
+.rspec

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ would yield an object:
       time_travel_machine = cfn_model.resources_by_type('AWS::TimeTravel::Machine').first
       expect(time_travel_machine.fuel).to eq 'dilithium'
       
+# Tests
+
+- run `rake spec` to execute serverspec tests
+
 # Deeper Dive
 
 ## Parsing

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,27 @@
+require 'rake'
+require 'rspec/core/rake_task'
+
+task :spec    => 'spec:all'
+task :default => :spec
+
+namespace :spec do
+  targets = []
+  Dir.glob('./spec/*').each do |dir|
+    next unless File.directory?(dir)
+    target = File.basename(dir)
+    target = "_#{target}" if target == "default"
+    targets << target
+  end
+
+  task :all     => targets
+  task :default => :all
+
+  targets.each do |target|
+    original_target = target == "_default" ? target[1..-1] : target
+    desc "Run Rspec tests to #{original_target}"
+    RSpec::Core::RakeTask.new(target.to_sym) do |t|
+      ENV['TARGET_HOST'] = original_target
+      t.pattern = "spec/#{original_target}/*_spec.rb"
+    end
+  end
+end

--- a/lib/cfn-model/schema/AWS_EC2_Instance.yml
+++ b/lib/cfn-model/schema/AWS_EC2_Instance.yml
@@ -9,10 +9,6 @@ mapping:
     type: map
     required: yes
     mapping:
-      ImageId:
-        type: any
-        required: yes
-
       =:
         type: any
   =:

--- a/spec/parser/cfn_parser_ec2_instance_spec.rb
+++ b/spec/parser/cfn_parser_ec2_instance_spec.rb
@@ -13,12 +13,10 @@ describe CfnParser do
         cfn_model = @cfn_parser.parse IO.read(test_template)
 
         ec2_instances = cfn_model.resources_by_type('AWS::EC2::Instance')
-
         expect(ec2_instances.size).to eq 1
+
         ec2_instance = ec2_instances.first
-
         expected_security_group = security_group_with_one_ingress_and_one_egress_rule
-
         actual_security_group = ec2_instance.security_groups.first
         expect(actual_security_group).to eq expected_security_group
       end
@@ -31,11 +29,26 @@ describe CfnParser do
         cfn_model = @cfn_parser.parse IO.read(test_template)
 
         ec2_instances = cfn_model.resources_by_type('AWS::EC2::Instance')
-
         expect(ec2_instances.size).to eq 1
-        ec2_instance = ec2_instances.first
 
+        ec2_instance = ec2_instances.first
         expect(ec2_instance.security_groups.size).to eq 0
+      end
+    end
+  end
+
+  context 'an ec2 instance with a launch template', :ec2 do
+    it 'returns ec2 instance with launch template' do
+      yaml_test_templates('ec2_instance/instance_with_launch_template').each do |test_template|
+        cfn_model = @cfn_parser.parse IO.read(test_template)
+
+        ec2_launch_templates = cfn_model.resources_by_type('AWS::EC2::LaunchTemplate')
+        expect(ec2_launch_templates.size).to eq 1
+
+        ec2_instances = cfn_model.resources_by_type('AWS::EC2::Instance')
+        expect(ec2_instances.size).to eq 1
+        expect(ec2_instances[0].launchTemplate).not_to be_empty
+        expect(ec2_instances[0].imageId).to be_nil
       end
     end
   end

--- a/spec/test_templates/yaml/ec2_instance/instance_with_launch_template.yml
+++ b/spec/test_templates/yaml/ec2_instance/instance_with_launch_template.yml
@@ -1,0 +1,21 @@
+Parameters:
+  ImageId:
+    Type: String
+    Default: ami-97785bed
+  InstanceType:
+    Type: String
+    Default: t2.micro
+
+Resources:
+  Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      LaunchTemplate:
+        LaunchTemplateId: !Ref LaunchTemplate
+        Version: 1
+  LaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        ImageId: !Ref ImageId
+        InstanceType: !Ref InstanceType


### PR DESCRIPTION
With the new AWS::EC2::LaunchTemplate resource, previously required properties in
AWS::EC2::Instance are no longer required, when LaunchTemplateId is specified.

https://github.com/stelligent/cfn_nag/issues/136