### PR TITLE
Ignore Fn::Transform key under resource properties

### DIFF
--- a/lib/cfn-model/parser/cfn_parser.rb
+++ b/lib/cfn-model/parser/cfn_parser.rb
@@ -176,6 +176,7 @@ class CfnParser
   def assign_fields_based_upon_properties(resource_object, resource)
     unless resource['Properties'].nil?
       resource['Properties'].each do |property_name, property_value|
+        next if %w(Fn::Transform).include? property_name
         resource_object.send("#{map_property_name_to_attribute(property_name)}=", property_value)
       end
     end

--- a/spec/parser/cfn_parser_spec.rb
+++ b/spec/parser/cfn_parser_spec.rb
@@ -189,4 +189,28 @@ END
       }.to raise_error JSON::ParserError
     end
   end
+
+  context 'a template with Fn::Transform under Properties' do
+    it 'ignores' do
+      cloudformation_yml = <<END
+---
+Resources:
+  newResource:
+    Type: "AWS::TimeTravel::Machine"
+    Properties:
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location: include.yml
+      Fuel: dilithium
+END
+      cfn_model = @cfn_parser.parse cloudformation_yml
+
+      expect(cfn_model.resources.size).to eq 1
+
+      time_travel_machine = cfn_model.resources_by_type('AWS::TimeTravel::Machine').first
+      expect(time_travel_machine.is_a?(ModelElement)).to eq true
+      expect(time_travel_machine.fuel).to eq 'dilithium'
+    end
+  end
 end


### PR DESCRIPTION
Will get the error ```'instance_variable_get': '@fn::Transform=' is not allowed as an instance variable name (NameError)``` without this.