### PR TITLE
#52 Adding Alexa resource type, aiding in cfn_nag issue #322

### DIFF
--- a/lib/cfn-model/parser/cfn_parser.rb
+++ b/lib/cfn-model/parser/cfn_parser.rb
@@ -202,7 +202,7 @@ class CfnParser
     resource_class = Class.new(ModelElement)
 
     module_names = type_name.split('::')
-    if module_names.first == 'Custom'
+    if %w[Alexa Custom].include?(module_names.first)
       custom_resource_class_name = initial_upper(module_names[1])
       begin
         resource_class = Object.const_get custom_resource_class_name

--- a/spec/parser/cfn_parser_spec.rb
+++ b/spec/parser/cfn_parser_spec.rb
@@ -92,6 +92,50 @@ END
       end
     end
 
+    context 'a template with alexa resource type' do
+      it 'returns model with parameters' do
+        cloudformation_yml = <<END
+---
+Resources:
+  alexaResource:
+    Type: "Alexa::ASK::Skill"
+    Properties:
+      SkillPackage:
+        S3Bucket: foo-bucket
+        S3Key: bar.zip
+      VendorId: foobar
+END
+        cfn_model = @cfn_parser.parse cloudformation_yml
+        alexa_ask_skill = cfn_model.resources_by_type('Alexa::ASK::Skill').first
+
+        expect(cfn_model.resources.size).to eq 1
+        expect(alexa_ask_skill.is_a?(ModelElement)).to eq true
+        expect(alexa_ask_skill.logical_resource_id).to eq 'alexaResource'
+        expect(alexa_ask_skill.resource_type).to eq 'Alexa::ASK::Skill'
+        expect(alexa_ask_skill.skillPackage['S3Bucket']).to eq 'foo-bucket'
+        expect(alexa_ask_skill.skillPackage['S3Key']).to eq 'bar.zip'
+        expect(alexa_ask_skill.vendorId).to eq 'foobar'
+      end
+    end
+
+    context 'a template with invalid foo resource type' do
+      it 'returns runtime error' do
+        cloudformation_yml = <<END
+---
+Resources:
+  fooResource:
+    Type: "Foo::Bar::Baz"
+    Properties:
+      foo:
+        bar: baz
+END
+
+        expect {
+          @cfn_parser.parse cloudformation_yml
+        }.to raise_error RuntimeError
+      end
+    end
+
     context 'a template with empty Resources' do
       it 'returns a parse error' do
         expect {


### PR DESCRIPTION
This feature adds the `Alexa` resource type to `CfnParser`.

This is needed for the CloudFormation Alexa ASK Skill Resource found here:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ask-skill.html

Adding this allows for secure password rules to be created in cfn_nag for https://github.com/stelligent/cfn_nag/issues/322
