### PR TITLE
#335 Adding parser for KMS keys and associated key policies

### DIFF
--- a/lib/cfn-model/model/kms_key.rb
+++ b/lib/cfn-model/model/kms_key.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative 'model_element'
+
+class AWS::KMS::Key < ModelElement
+  attr_accessor :key_policy
+
+  def initialize(cfn_model)
+    super
+    @key_policy = nil
+    @resource_type = 'AWS::KMS::Key'
+  end
+end

--- a/lib/cfn-model/model/model_element.rb
+++ b/lib/cfn-model/model/model_element.rb
@@ -23,6 +23,10 @@ module AWS
 
   end
 
+  module KMS
+
+  end
+
   module S3
 
   end

--- a/lib/cfn-model/parser/kms_key_parser.rb
+++ b/lib/cfn-model/parser/kms_key_parser.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'cfn-model/model/kms_key'
+require 'cfn-model/model/policy'
+require_relative 'policy_document_parser'
+
+class KmsKeyParser
+  def parse(cfn_model:, resource:)
+    kms_key = resource
+
+    new_policy = Policy.new
+    new_policy.policy_document = PolicyDocumentParser.new.parse(kms_key.keyPolicy)
+    kms_key.key_policy = new_policy
+
+    kms_key
+  end
+end

--- a/lib/cfn-model/parser/parser_registry.rb
+++ b/lib/cfn-model/parser/parser_registry.rb
@@ -17,6 +17,7 @@ class ParserRegistry
       'AWS::IAM::Role' => IamRoleParser,
       'AWS::IAM::Policy' => WithPolicyDocumentParser,
       'AWS::IAM::ManagedPolicy' => WithPolicyDocumentParser,
+      'AWS::KMS::Key' => KmsKeyParser,
       'AWS::S3::BucketPolicy' => WithPolicyDocumentParser,
       'AWS::SNS::TopicPolicy' => WithPolicyDocumentParser,
       'AWS::SQS::QueuePolicy' => WithPolicyDocumentParser

--- a/lib/cfn-model/schema/AWS_KMS_Key.yml
+++ b/lib/cfn-model/schema/AWS_KMS_Key.yml
@@ -1,0 +1,18 @@
+---
+type: map
+mapping:
+  Type:
+    type: str
+    required: yes
+    pattern: /AWS::KMS::Key/
+  Properties:
+    type: map
+    required: yes
+    mapping:
+      KeyPolicy:
+        type:   any
+        required: yes
+      =:
+        type: any
+  =:
+    type: any

--- a/spec/factories/kms_key.rb
+++ b/spec/factories/kms_key.rb
@@ -1,0 +1,37 @@
+require 'cfn-model/model/kms_key'
+
+def kms_key_with_single_statement(cfn_model: CfnModel.new)
+  statement = Statement.new
+  statement.effect = 'Allow'
+  statement.actions << 'kms:*'
+  statement.resources << '*'
+  statement.principal = {
+    'AWS' => 'arn:aws:iam::123456789012:user/Test'
+  }
+
+  policy_document = PolicyDocument.new
+  policy_document.version = '2012-10-17'
+  policy_document.statements << statement
+
+  policy = Policy.new
+  policy.policy_document = policy_document
+
+  key = AWS::KMS::Key.new cfn_model
+  key.key_policy = policy
+  key.keyPolicy = {
+    "Version"=>"2012-10-17",
+    "Statement"=>{
+      "Effect"=>"Allow",
+      "Action"=>"kms:*",
+      "Principal"=>{"AWS"=>"arn:aws:iam::123456789012:user/Test"},
+      "Resource"=>"*"}}
+  key.raw_model = {
+    "AWSTemplateFormatVersion"=>"2010-09-09",
+    "Resources"=>{
+      "RootKey"=>{
+        "Type"=>"AWS::KMS::Key",
+        "Properties"=>{
+          "KeyPolicy"=>key.keyPolicy}}}}
+
+  key
+end

--- a/spec/parser/cfn_parser_kms_key_spec.rb
+++ b/spec/parser/cfn_parser_kms_key_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'cfn-model/parser/cfn_parser'
+require 'cfn-model/parser/parser_error'
+
+describe CfnParser do
+  before :each do
+    @cfn_parser = CfnParser.new
+  end
+
+  context 'a kms key without a KeyPolicy' do
+    it 'raises an error' do
+      test_templates('kms_key/kms_key_without_key_policy').each do |test_template|
+        begin
+          _ = @cfn_parser.parse IO.read(test_template)
+        rescue Exception => parse_error
+          begin
+            expect(parse_error.is_a?(ParserError)).to eq true
+            expect(parse_error.errors.size).to eq(1)
+            expect(parse_error.errors[0].to_s).to eq("[/Resources/RootKey/Properties] key 'KeyPolicy:' is required.")
+          rescue RSpec::Expectations::ExpectationNotMetError
+            $!.message << "in file: #{test_template}"
+            raise
+          end
+        end
+      end
+    end
+  end
+
+  context 'a kms key with a single statement' do
+    it 'returns key with statements array of size 1' do
+      test_templates('kms_key/kms_key_with_single_statement').each do |test_template|
+        cfn_model = @cfn_parser.parse IO.read(test_template)
+
+        keys = cfn_model.resources_by_type('AWS::KMS::Key')
+
+        expect(keys.size).to eq 1
+        key = keys.first
+
+        expect(key).to eq kms_key_with_single_statement
+      end
+    end
+  end
+end

--- a/spec/test_templates/json/kms_key/kms_key_with_single_statement.json
+++ b/spec/test_templates/json/kms_key/kms_key_with_single_statement.json
@@ -1,0 +1,19 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "RootKey": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+        "KeyPolicy": {
+					"Version" : "2012-10-17",
+					"Statement": {
+						"Effect": "Allow",
+						"Action": "kms:*",
+						"Principal": {"AWS": "arn:aws:iam::123456789012:user/Test"},
+						"Resource": "*"
+					}
+				}
+      }
+    }
+  }
+}

--- a/spec/test_templates/json/kms_key/kms_key_with_single_statement.json
+++ b/spec/test_templates/json/kms_key/kms_key_with_single_statement.json
@@ -5,14 +5,14 @@
       "Type": "AWS::KMS::Key",
       "Properties": {
         "KeyPolicy": {
-					"Version" : "2012-10-17",
-					"Statement": {
-						"Effect": "Allow",
-						"Action": "kms:*",
-						"Principal": {"AWS": "arn:aws:iam::123456789012:user/Test"},
-						"Resource": "*"
-					}
-				}
+          "Version" : "2012-10-17",
+          "Statement": {
+            "Effect": "Allow",
+            "Action": "kms:*",
+            "Principal": {"AWS": "arn:aws:iam::123456789012:user/Test"},
+            "Resource": "*"
+          }
+        }
       }
     }
   }

--- a/spec/test_templates/json/kms_key/kms_key_without_key_policy.json
+++ b/spec/test_templates/json/kms_key/kms_key_without_key_policy.json
@@ -4,7 +4,7 @@
     "RootKey": {
       "Type": "AWS::KMS::Key",
       "Properties": {
-				"EnableKeyRotation": "true"
+        "EnableKeyRotation": "true"
       }
     }
   }

--- a/spec/test_templates/json/kms_key/kms_key_without_key_policy.json
+++ b/spec/test_templates/json/kms_key/kms_key_without_key_policy.json
@@ -1,0 +1,11 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "RootKey": {
+      "Type": "AWS::KMS::Key",
+      "Properties": {
+				"EnableKeyRotation": "true"
+      }
+    }
+  }
+}

--- a/spec/test_templates/yaml/kms_key/kms_key_with_single_statement.yml
+++ b/spec/test_templates/yaml/kms_key/kms_key_with_single_statement.yml
@@ -1,0 +1,14 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  RootKey:
+    Type: "AWS::KMS::Key"
+    Properties:
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          Effect: "Allow"
+          Action: "kms:*"
+          Principal:
+            AWS: "arn:aws:iam::123456789012:user/Test"
+          Resource: "*"

--- a/spec/test_templates/yaml/kms_key/kms_key_without_key_policy.yml
+++ b/spec/test_templates/yaml/kms_key/kms_key_without_key_policy.yml
@@ -1,0 +1,7 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  RootKey:
+    Type: "AWS::KMS::Key"
+    Properties:
+      EnableKeyRotation: true


### PR DESCRIPTION
[stelligent/cfn_nag issue #335](https://github.com/stelligent/cfn_nag/issues/335)

### Description
Adding parsing for KMS keys and associated policies to ease the creation of KMS custom rules in [stelligent/cfn_nag](https://github.com/stelligent/cfn_nag).

### Testing
Rspec test suite includes both positive and negative test cases from JSON templates, which pass while covering all relevant logic in the parser.  Added YAML templates for integration testing as well.

#### Example rspec Output
```
$ bundle exec rspec spec/parser/cfn_parser_kms_key_spec.rb
..

Finished in 0.0075 seconds (files took 0.19937 seconds to load)
2 examples, 0 failures

Coverage report generated for RSpec to cfn-model/coverage. 499 / 922 LOC (54.12%) covered.
$
```