### PR TITLE
Updating deprecated 'version' property to 'ruby-version' for setup-ruby action

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Ruby 2.5
       uses: actions/setup-ruby@v1
       with:
-        version: 2.5.x
+        ruby-version: 2.5.x
     - name: Install Bundler
       run: gem install bundler
     - name: Which bundler?
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Ruby 2.5
         uses: actions/setup-ruby@v1
         with:
-          version: 2.5.x
+          ruby-version: 2.5.x
       - name: Publish to RubyGems
         run: bash ./publish.sh
         env:


### PR DESCRIPTION
### Description
As of October 1, 2019 the `version` property of the [setup-ruby](https://github.com/actions/setup-ruby) action was deprecated and replaced by `ruby-version`.  This PR updates all instances of `version` to `ruby-version` in [gempush.yml](.github/workflows/gempush.yml).