### PR TITLE
stelligent/cfn_nag#74 Reworking Serverless transform to more closely match how SAM transforms templates

### DIFF
--- a/lib/cfn-model/transforms/serverless.rb
+++ b/lib/cfn-model/transforms/serverless.rb
@@ -69,7 +69,7 @@ class CfnModel
       end
 
       def format_function_role(serverless_function, function_name)
-        getatt_hash = { 'Fn::GetAtt' => ["#{function_name}Role", 'Arn'] }
+        getatt_hash = { 'Fn::GetAtt' => %W[#{function_name}Role Arn] }
         serverless_function['Properties']['Role'] || getatt_hash
       end
 
@@ -153,13 +153,13 @@ class CfnModel
 
       def function_role_managed_policies(function_properties)
         # Always set AWSLambdaBasicExecutionRole policy
-        base_policies = ['arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole']
+        base_policies = %w[arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole]
 
         # Return base_policies if no policies assigned to the function
         return base_policies unless function_properties['Policies']
 
         # If the SAM function Policies property is a string, append and return
-        return base_policies | ["arn:aws:iam::aws:policy/#{function_properties['Policies']}"] if \
+        return base_policies | %W[arn:aws:iam::aws:policy/#{function_properties['Policies']}] if \
           function_properties['Policies'].is_a? String
 
         # Iterate on Policies property and add if String

--- a/spec/transforms/serverless_spec.rb
+++ b/spec/transforms/serverless_spec.rb
@@ -66,7 +66,7 @@ describe CfnModel::Transforms::Serverless do
         yaml_test_template('sam/valid_simple_lambda_fn')
       actual_cfn_model = @cfn_parser.parse cloudformation_template_yml
       expect(
-        actual_cfn_model.raw_model['Resources']['FunctionNameRole']['Type']
+        actual_cfn_model.raw_model['Resources']['MyServerlessFunctionLogicalIDRole']['Type']
       ).to(
         eq 'AWS::IAM::Role'
       )


### PR DESCRIPTION
Updates stelligent/cfn_nag#74

### Description

In order to properly audit permissions assigned to serverless functions, the roles which are generated must closely match those coming directly from SAM.  This PR changes the Serverless transform in cfn-model to:
1. Generating an IAM role for each serverless function, if Role property not provided.
2. Parsing serverless function properties to correctly populate generated role.
3. Updating spec tests.

As you'll see in the Testing section below, this allows utilization of all cfn_nag custom rules against the resultant roles.

### Testing

1. All rspec tests pass.
2. Test runs of cfn_nag against a test YAML template showed individual roles per serverless function (unless a Role property was specified) and more appropriate output of custom rule audits.

#### Before

```
------------------------------------------------------------
spec/test_templates/yaml/sam/serverless_rest_api_with_basepathmapping.yml
------------------------------------------------------------
Failures count: 0
Warnings count: 0
```

[raw_model.before.txt](https://github.com/stelligent/cfn-model/files/4262302/raw_model.before.txt)

#### After

```
------------------------------------------------------------
spec/test_templates/yaml/sam/serverless_rest_api_with_basepathmapping.yml
------------------------------------------------------------------------------------------------------------------------
| WARN W43
|
| Resources: ["FunctionWithAdministratorAccessPolicyRole"]
| Line Numbers: [-1]
|
| IAM role should not have AdministratorAccess policy
------------------------------------------------------------
| WARN W44
|
| Resources: ["FunctionWithPowerUserPolicyAndPolicyTemplateRole"]
| Line Numbers: [-1]
|
| IAM role should not have Elevated Managed policy
------------------------------------------------------------
| FAIL F38
|
| Resources: ["FunctionWithInlineAdminPolicyRole"]
| Line Numbers: [-1]
|
| IAM role should not allow * resource with PassRole action on its permissions policy
------------------------------------------------------------
| FAIL F3
|
| Resources: ["FunctionWithInlineAdminPolicyRole"]
| Line Numbers: [-1]
|
| IAM role should not allow * action on its permissions policy
------------------------------------------------------------
| WARN W11
|
| Resources: ["FunctionWithInlineAdminPolicyRole"]
| Line Numbers: [-1]
|
| IAM role should not allow * resource on its permissions policy
------------------------------------------------------------
| WARN W58
|
| Resources: ["FunctionWithExternalRole"]
| Line Numbers: [-1]
|
| Lambda functions require permission to write CloudWatch Logs

Failures count: 2
Warnings count: 4
```

[raw_model.after.txt](https://github.com/stelligent/cfn-model/files/4262252/raw_model.after.txt)