### PR TITLE
Create VS Code remote dev container for cfn-model

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM stelligent/vscode-remote-cfn-model:latest

--- a/.devcontainer/build/Dockerfile
+++ b/.devcontainer/build/Dockerfile
@@ -1,0 +1,65 @@
+FROM ruby:2.5
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update package tool
+RUN apt-get update
+
+# Install apt-utils and suppress package configuration warning
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1
+
+# Install build tools
+RUN apt-get install -y --no-install-recommends build-essential \
+    git
+
+# Install Docker CE CLI
+RUN apt-get install -y apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg-agent \
+    software-properties-common \
+    lsb-release \
+    && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | apt-key add - 2>/dev/null \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" \
+    && apt-get update \
+    && apt-get install -y docker-ce-cli
+
+# Install gems
+RUN gem install bundler
+RUN gem install rubocop
+RUN gem install solargraph
+
+# Install cfn-lint via pip
+RUN apt-get install -y python3-pip
+RUN pip3 install cfn-lint
+
+# Create a non-root user and provide sudo rights
+ARG USERNAME=cfn-model_dev
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+RUN groupadd --gid $USER_GID $USERNAME \
+  && useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash -m $USERNAME \
+  && apt-get install -y sudo \
+  && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+  && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Persist bash history between runs
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+    && mkdir /commandhistory \
+    && touch /commandhistory/.bash_history \
+    && chown -R $USERNAME /commandhistory \
+    && echo $SNIPPET >> "/home/$USERNAME/.bashrc"
+
+# Prompt gpg window inside container for signing commits & setup folder permissions for non-root user
+RUN echo 'export GPG_TTY="$(tty)"' >> /home/$USERNAME/.bashrc \
+  && mkdir /home/$USERNAME/.gnupg \
+  && chown -R $USERNAME /home/$USERNAME/.gnupg
+
+# Add non-root user to gems and bundle
+RUN chown -R $USERNAME /usr/local/lib/ruby/gems/2.5.0 \
+  && chown -R $USERNAME /usr/local/bundle
+
+# Enter container as non-root user
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,118 @@
+{
+	"name": "cfn-model Development",
+	"dockerFile": "Dockerfile",
+	"appPort": 9001,
+	"remote.containers.workspaceMountConsistency": "consistent",
+	"containerEnv": {
+		// Docker-in-Docker Present Working Directory
+		"DND_PWD": "${localEnv:PWD}"
+	},
+	"mounts": [
+		// Bash History
+		"source=cfn-model-bash_history,target=/commandhistory,type=volume",
+		// Docker in Docker
+		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+	],
+	"runArgs": [
+		// SSH
+		"-v", "${localEnv:HOME}/.ssh:/home/cfn-model_dev/.ssh:ro",
+		// GPG
+		"-v", "${localEnv:HOME}/.gnupg/private-keys-v1.d:/home/cfn-model_dev/.gnupg/private-keys-v1.d:ro",
+		"-v", "${localEnv:HOME}/.gnupg/pubring.kbx:/home/cfn-model_dev/.gnupg/pubring.kbx:ro",
+		"-v", "${localEnv:HOME}/.gnupg/trustdb.gpg:/home/cfn-model_dev/.gnupg/trustdb.gpg:ro"
+	],
+	"extensions": [
+		// General
+		"CoenraadS.bracket-pair-colorizer",
+		"fabiospampinato.vscode-diff",
+		"kddejong.vscode-cfn-lint",
+		"mrmlnc.vscode-duplicate",
+		"ms-azuretools.vscode-docker",
+		"wayou.vscode-todo-highlight",
+		// Ruby
+		"rebornix.Ruby",
+		"castwide.solargraph",
+		"kaiwood.endwise",
+		"misogi.ruby-rubocop",
+		"groksrc.ruby",
+		"hoovercj.ruby-linter",
+		"miguel-savignano.ruby-symbols",
+		"wingrunr21.vscode-ruby",
+		// JSON
+		"mohsen1.prettify-json",
+		// YAML
+		"redhat.vscode-yaml"
+	],
+	"settings": {
+		// Bracket Pair Colorizer
+		"bracketPairColorizer.forceUniqueOpeningColor": false,
+		"bracketPairColorizer.colorMode": "Consecutive",
+		"bracketPairColorizer.highlightActiveScope": true,
+		"bracketPairColorizer.activeScopeCSS": [
+			"borderStyle : solid",
+			"borderWidth : 1px",
+			"borderColor : {color}; opacity: 0.5",
+			"backgroundColor : {color}"
+		],
+		"editor.matchBrackets": "never",
+		"bracketPairColorizer.showBracketsInGutter": true,
+		// cfn-lint
+		"cfnLint.path": "/usr/local/bin/cfn-lint",
+		// Ruby
+		"[ruby]": {
+			"editor.insertSpaces": true,
+			"editor.tabSize": 2
+		},
+		// Solargraph
+		"solargraph.commandPath": "/usr/local/bundle/bin/solargraph",
+		"solargraph.bundlerPath": "/usr/local/bin/bundle",
+		// Rubocop
+		"ruby.rubocop.executePath": "/usr/local/bundle/bin/",
+		"ruby.rubocop.onSave": true,
+		"ruby.rubocop.configFilePath": "/workspaces/cfn-model/.rubocop.yml",
+		// YAML
+		"[yaml]": {
+			"editor.insertSpaces": true,
+			"editor.tabSize": 2
+		},
+		"yaml.format.enable": true,
+		"yaml.format.singleQuote": true,
+		"yaml.format.bracketSpacing": true,
+		"yaml.format.printWidth": 120,
+		"yaml.format.proseWrap": "always",
+		"yaml.customTags": [
+			"!And sequence",
+			"!If sequence",
+			"!Not sequence",
+			"!Equals sequence",
+			"!Or sequence",
+			"!FindInMap sequence",
+			"!Base64",
+			"!Cidr sequence",
+			"!Ref",
+			"!Sub",
+			"!GetAtt",
+			"!GetAZs",
+			"!ImportValue",
+			"!Select sequence",
+			"!Split sequence",
+			"!Join sequence",
+			"!And",
+			"!If",
+			"!Not",
+			"!Equals",
+			"!Or",
+			"!FindInMap",
+			"!Cidr",
+			"!Select",
+			"!Split",
+			"!Join",
+			"!Sub sequence",
+			"!ImportValue sequence"
+		],
+		// TODO
+		"todohighlight.isEnable": true,
+		"todohighlight.isCaseSensitive": false
+	},
+	"postCreateCommand": "bundle install"
+}

--- a/.github/workflows/vscode_remote_development.yml
+++ b/.github/workflows/vscode_remote_development.yml
@@ -1,0 +1,33 @@
+name: VS Code DockerHub Build & Push
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - '.devcontainer/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: checkout
+        uses: actions/checkout@master
+      -
+        name: docker login
+        env:
+          DOCKER_USER: ${{ secrets.docker_user }}
+          DOCKER_PASSWORD: ${{ secrets.docker_password }}
+        run: |
+          echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin
+      -
+        name: Build & Push to DockerHub
+        env:
+          DOCKER_ORG: stelligent
+          DOCKER_REPO: vscode-remote-cfn-model
+        run: |
+          docker build -t $DOCKER_ORG/$DOCKER_REPO:${GITHUB_SHA::8} --file .devcontainer/build/Dockerfile .
+          docker tag $DOCKER_ORG/$DOCKER_REPO:${GITHUB_SHA::8} $DOCKER_ORG/$DOCKER_REPO:latest
+          docker push $DOCKER_ORG/$DOCKER_REPO:${GITHUB_SHA::8}
+          docker push $DOCKER_ORG/$DOCKER_REPO:latest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![cfn_model](https://github.com/stelligent/cfn-model/workflows/cfn_model/badge.svg)
+[![cfn_model](https://github.com/stelligent/cfn-model/workflows/cfn_model/badge.svg)](https://github.com/stelligent/cfn-model/actions?query=workflow%3Acfn_model) [![VS Code DockerHub Build & Push](https://github.com/stelligent/cfn-model/workflows/VS%20Code%20DockerHub%20Build%20&%20Push/badge.svg)](https://github.com/stelligent/cfn-model/actions?query=workflow%3A%22VS+Code+DockerHub+Build+%26+Push%22)
 
 # Overview
 
@@ -74,9 +74,31 @@ would yield an object:
       time_travel_machine = cfn_model.resources_by_type('AWS::TimeTravel::Machine').first
       expect(time_travel_machine.fuel).to eq 'dilithium'
       
-# Tests
+# Development
 
-- run `rake spec` to execute serverspec tests
+## Specs
+
+To run the specs, you need to ensure you have Docker installed and cfn-model dependencies installed via
+```
+gem install bundle
+bundle install
+```
+
+Then, to run all of the specs, just run `rake spec`.
+
+## VS Code Remote Development
+There is a complete remote development environment created and setup with all the tools and settings pre-configured for ease in rule development and creation. You can enable this by using the VS Code Remote development functionality.
+
+- Install the VS Code [Remote Development extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)
+- Open the repo in VS Code
+- When prompted "`Folder contains a dev container configuration file. Reopen folder to develop in a container`" click the "`Reopen in Container`" button
+- When opening in the future use the "`[Dev Container] cfn_nag Development`" option
+
+More information about the VS Code Remote Development setup can be found here, [VS Code Remote Development](vscode_remote_development.md).
+
+# Support
+
+To report a bug or request a feature, submit an issue through the GitHub repository via: <https://github.com/stelligent/cfn-model/issues/new>
 
 # Deeper Dive
 

--- a/vscode_remote_development.md
+++ b/vscode_remote_development.md
@@ -1,0 +1,53 @@
+# VS Code Remote Development
+
+You can start working on developing with this project with relative ease by using the VS Code Remote Development extension. In this project there is a folder named `.devcontainer` that allows users to open the project in a docker container using the custom built development image. This development image has all the items needed to start working on the cfn_nag project right out of the box. All you need to do is open the project in the VS Code Remote Container to get started.
+
+- Install the VS Code [Remote Development extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)
+- Open the repo in VS Code
+- When prompted "`Folder contains a dev container configuration file. Reopen folder to develop in a container`" click the "`Reopen in Container`" button
+- When opening in the future use the "`[Dev Container] cfn_nag Development`" option
+
+## VS Code Dependencies
+
+There are a couple of dependencies that you need to configure locally before being able to fully utizlize the Remote Developemnt environment.
+- Requires `ms-vscode-remote.remote-containers` >= `0.101.0`
+- [Docker](https://www.docker.com/products/docker-desktop)
+  - Needs to be installed in order to use the remote development container
+- [GPG](https://gpgtools.org)
+  - Should to be installed in `~/.gnupg/` to be able to sign git commits with gpg
+- SSH
+  - Should to be installed in `~/.ssh` to be able to use your ssh config and keys.
+
+## Container Image
+
+### Docker Hub: stelligent/vscode-remote-cfn_nag
+
+The main `.devcontainer/Dockerfile` points to the latest `stelligent/vscode-remote-cfn_nag` Docker Hub container image. This image is created and pushed by a separate GitHub Actions Workflow. It will tag the newly created image with the short git sha and `latest`.
+
+### Build Dockerfile
+
+The `stelligent/vscode-remote-cfn_nag` container image is build and controlled by the `.devcontainer/build/Dockerfile`
+
+From within this file we are starting from the official Ruby 2.5 image and then going through and installing and configuring the necessary items for the remote build environment.
+
+Some important items to note here:
+* Installs the `docker` cli so that the `rake` tasks can still run from within the remote development container environment.
+* Installs gems needed for the project and vscode extensions.
+* Creates a non-root user (`cfn_nag_dev`) and provides `sudo` access so that the user can run the `rake` tasks that call the `docker` cli.
+* Creates a way for the `bash` command history to be saved between container runs.
+* Sets up the GPG home directory and sets the `tty` so that you can still sign git commits inside the container.
+
+## Container Settings
+
+The VS Code Remote Development container settings are controlled from within the `.devcontainer/devcontainer.json` file.
+
+Some important items to note here:
+* Container Mount Consistency is set to `consistent` to avoid a lag or mismatch from files that are changed during code editing from inside the remote container environment.
+* `DND_PWD` Environment Variable is created to help with the `rake` tasks that are executed while inside the remote container. The mount source needs to reference the local systems path from within the docker container.
+* Mounts:
+  * A volume is created and mounted to store the `bash` command line history from within the container. Now when you close the connection and reopen at a later date, you can still search for previously used commands as needed.
+  * The Docker socket is mounted so that you can still run `docker` commands from within the remote container environment.
+  * If it exists, your local ssh directory (`~/.ssh`) is mounted so that you still access your config and sshkeys to be able to connect to github with key authentication.
+  * If it exists, your local gpg items (`~/.gnupg`) are mounted so that you can still sign your commits and tags from within the remote container.
+* Several vscode extensions are installed to help the user jumping right into project development. These extensions also have custom configured settings to work within the remote container environment.
+* Runs `bundle install` so that everything is fully setup for the user before they get logged into the connection. The user can simply just run the `rake` commands without needing to set anything else up.

--- a/vscode_remote_development.md
+++ b/vscode_remote_development.md
@@ -1,11 +1,11 @@
 # VS Code Remote Development
 
-You can start working on developing with this project with relative ease by using the VS Code Remote Development extension. In this project there is a folder named `.devcontainer` that allows users to open the project in a docker container using the custom built development image. This development image has all the items needed to start working on the cfn_nag project right out of the box. All you need to do is open the project in the VS Code Remote Container to get started.
+You can start working on developing with this project with relative ease by using the VS Code Remote Development extension. In this project there is a folder named `.devcontainer` that allows users to open the project in a docker container using the custom built development image. This development image has all the items needed to start working on the cfn-model project right out of the box. All you need to do is open the project in the VS Code Remote Container to get started.
 
 - Install the VS Code [Remote Development extension pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)
 - Open the repo in VS Code
 - When prompted "`Folder contains a dev container configuration file. Reopen folder to develop in a container`" click the "`Reopen in Container`" button
-- When opening in the future use the "`[Dev Container] cfn_nag Development`" option
+- When opening in the future use the "`[Dev Container] cfn-model Development`" option
 
 ## VS Code Dependencies
 
@@ -20,20 +20,20 @@ There are a couple of dependencies that you need to configure locally before bei
 
 ## Container Image
 
-### Docker Hub: stelligent/vscode-remote-cfn_nag
+### Docker Hub: stelligent/vscode-remote-cfn-model
 
-The main `.devcontainer/Dockerfile` points to the latest `stelligent/vscode-remote-cfn_nag` Docker Hub container image. This image is created and pushed by a separate GitHub Actions Workflow. It will tag the newly created image with the short git sha and `latest`.
+The main `.devcontainer/Dockerfile` points to the latest `stelligent/vscode-remote-cfn-model` Docker Hub container image. This image is created and pushed by a separate GitHub Actions Workflow. It will tag the newly created image with the short git sha and `latest`.
 
 ### Build Dockerfile
 
-The `stelligent/vscode-remote-cfn_nag` container image is build and controlled by the `.devcontainer/build/Dockerfile`
+The `stelligent/vscode-remote-cfn-model` container image is build and controlled by the `.devcontainer/build/Dockerfile`
 
 From within this file we are starting from the official Ruby 2.5 image and then going through and installing and configuring the necessary items for the remote build environment.
 
 Some important items to note here:
 * Installs the `docker` cli so that the `rake` tasks can still run from within the remote development container environment.
 * Installs gems needed for the project and vscode extensions.
-* Creates a non-root user (`cfn_nag_dev`) and provides `sudo` access so that the user can run the `rake` tasks that call the `docker` cli.
+* Creates a non-root user (`cfn-model_dev`) and provides `sudo` access so that the user can run the `rake` tasks that call the `docker` cli.
 * Creates a way for the `bash` command history to be saved between container runs.
 * Sets up the GPG home directory and sets the `tty` so that you can still sign git commits inside the container.
 


### PR DESCRIPTION
### Description

Immense thanks to @phelewski for his work on the [cfn_nag VS Code remote dev container](https://github.com/stelligent/cfn_nag/tree/master/.devcontainer), which made creating this container a breeze!

This PR creates a Docker container to setup a VS Code development environment for cfn-model, and eases the barrier to entry for cfn-model development.  It also creates a new GitHub workflow to build the Docker image and push it to [DockerHub](https://hub.docker.com/r/stelligent/vscode-remote-cfn-model).  Finally, it updates the documentation on use of the dev container.

### Testing

1. All rspec regression tests passed.
```
$ rspec
........................................................................................................................................................................

Finished in 0.77708 seconds (files took 0.56235 seconds to load)
168 examples, 0 failures

Coverage report generated for RSpec to /workspaces/cfn-model/coverage. 1029 / 1063 LOC (96.8%) covered.
```

2. The final commit of this PR was committed and pushed from the remote dev container!  🎉 