### PR TITLE
stelligent/cfn_nag#416 Better error handling when parsing UTF-8 encodings

### DIFF
--- a/bin/cfn_parse
+++ b/bin/cfn_parse
@@ -4,5 +4,5 @@ require 'cfn-model'
 puts '======'
 puts ARGV[0]
 puts '======'
-cfn_model = CfnParser.new.parse IO.read(ARGV[0]), nil, true
+cfn_model = CfnParser.new.parse IO.read(ARGV[0], encoding: Encoding::UTF_8), nil, true
 puts cfn_model

--- a/lib/cfn-model/model/references.rb
+++ b/lib/cfn-model/model/references.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'cfn-model/parser/parser_error'
+
 ##
 # this is a placeholder for anything related to resolving references
 #
@@ -43,6 +45,8 @@ module References
       # so don't/can't link it up
       return nil
     end
+  rescue NoMethodError => e
+    raise ParserError, e.inspect
   end
 
   def self.is_security_group_id_external(group_id)

--- a/lib/cfn-model/validator/cloudformation_validator.rb
+++ b/lib/cfn-model/validator/cloudformation_validator.rb
@@ -13,6 +13,8 @@ class CloudFormationValidator
     schema = SchemaGenerator.new.generate cloudformation_string
     validator = Kwalify::Validator.new(schema)
     validator.validate(YAML.load(cloudformation_string))
+  rescue ArgumentError, IOError, NameError => e
+    raise ParserError, e.inspect
   end
 
   private
@@ -21,8 +23,6 @@ class CloudFormationValidator
     first_character = cloudformation_string.gsub(/\s/, '').split('').first
     matches = cloudformation_string.scan(/\{[^}]*\}/)
     first_character == '{' && !matches.empty?
-  rescue ArgumentError => e
-    raise ParserError, e.inspect
   end
 
   def valid_json?(cloudformation_string)

--- a/lib/cfn-model/validator/cloudformation_validator.rb
+++ b/lib/cfn-model/validator/cloudformation_validator.rb
@@ -21,6 +21,8 @@ class CloudFormationValidator
     first_character = cloudformation_string.gsub(/\s/, '').split('').first
     matches = cloudformation_string.scan(/\{[^}]*\}/)
     first_character == '{' && !matches.empty?
+  rescue ArgumentError => e
+    raise ParserError, e.inspect
   end
 
   def valid_json?(cloudformation_string)

--- a/spec/test_templates/json/template_with_utf8_characters.json
+++ b/spec/test_templates/json/template_with_utf8_characters.json
@@ -12,7 +12,7 @@
               "Service": [ "ec2.amazonaws.com" ],
               "AWS" : "arn:aws:iam::324320755747:root"
             },
-            "Actioñ": ["sts:AssumeRole"]
+            "Action": ["sts:AssumeRole"]
           }
         },
         "Path": "/",

--- a/spec/test_templates/json/template_with_utf8_characters.json
+++ b/spec/test_templates/json/template_with_utf8_characters.json
@@ -1,0 +1,35 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "RöotRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version" : "2012-10-17",
+          "Statement": {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": [ "ec2.amazonaws.com" ],
+              "AWS" : "arn:aws:iam::324320755747:root"
+            },
+            "Actioñ": ["sts:AssumeRole"]
+          }
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyName": "root",
+            "PolicyDocument": {
+              "Version" : "2012-10-17",
+              "Statement": {
+                "Effect": "Allow",
+                "Action": "*",
+                "Resource": "*"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/spec/test_templates/yaml/template_with_utf8_characters.yml
+++ b/spec/test_templates/yaml/template_with_utf8_characters.yml
@@ -1,0 +1,25 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  RöotRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          Effect: Allow
+          Principal:
+            Service:
+              - ec2.amazonaws.com
+            AWS: arn:aws:iam::324320755747:root
+          Actioñ:
+            - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              Effect: Allow
+              Action: '*'
+              Resource: '*'

--- a/spec/test_templates/yaml/template_with_utf8_characters.yml
+++ b/spec/test_templates/yaml/template_with_utf8_characters.yml
@@ -12,7 +12,7 @@ Resources:
             Service:
               - ec2.amazonaws.com
             AWS: arn:aws:iam::324320755747:root
-          Actioñ:
+          Action:
             - sts:AssumeRole
       Path: /
       Policies:

--- a/spec/validator/cloudformation_validator_spec.rb
+++ b/spec/validator/cloudformation_validator_spec.rb
@@ -50,6 +50,46 @@ TEMPLATE
       end
     end
 
+    it 'raises an error when JSON contains UTF-8 characters' do
+      invalid_character_json = File.read(
+        'spec/test_templates/json/template_with_utf8_characters.json'
+      )
+
+      expect do
+        CloudFormationValidator.new.validate(invalid_character_json)
+      end.to raise_error ParserError, /invalid byte sequence in US-ASCII/
+    end
+
+    it 'does not raise an error when JSON contains UTF-8 characters and ' \
+       'read with correct encoding' do
+      invalid_character_json = File.read(
+        'spec/test_templates/json/template_with_utf8_characters.json',
+        encoding: Encoding::UTF_8
+      )
+
+      expect(CloudFormationValidator.new.validate(invalid_character_json)).to eq []
+    end
+
+    it 'raises an error when YAML contains UTF-8 characters' do
+      invalid_character_template = File.read(
+        'spec/test_templates/yaml/template_with_utf8_characters.yml'
+      )
+
+      expect do
+        CloudFormationValidator.new.validate(invalid_character_template)
+      end.to raise_error ParserError, /invalid byte sequence in US-ASCII/
+    end
+
+    it 'does not raise an error when YAML contains UTF-8 characters and ' \
+       'read with correct encoding' do
+      invalid_character_template = File.read(
+        'spec/test_templates/yaml/template_with_utf8_characters.yml',
+        encoding: Encoding::UTF_8
+      )
+
+      expect(CloudFormationValidator.new.validate(invalid_character_template)).to eq []
+    end
+
     it 'does not raise an error when JSON is valid' do
       valid_json = <<-TEMPLATE
       {


### PR DESCRIPTION
Updates stelligent/cfn_nag#416

## Description

Currently cfn-model parses templates with the assumption of `US-ASCII` encoding.  This causes errors when those templates include `UTF-8` or other encodings' characters.  To provide better handling of all templates, this PR introduces more error rescues in ruby to convert `ArgumentError`, `IOError`, and `NameError` to a `ParserError` when parsing the template which will [bubble up through to cfn_nag](https://github.com/stelligent/cfn_nag/blob/ae8a864b98d60a621a1fc0ef183e847c1b4e81fb/lib/cfn-nag/cfn_nag.rb#L97) (if cfn-model was called from it) and gracefully display error output per parsed template.

Current output:

```shell
cfn-model_dev@93c98da1d5c5:/workspaces/cfn-model$ bundle exec cfn_parse spec/test_templates/yaml/template_with_utf8_characters.yml 
======
spec/test_templates/yaml/template_with_utf8_characters.yml
======
bundler: failed to load command: cfn_parse (/usr/local/bundle/bin/cfn_parse)
ArgumentError: invalid byte sequence in US-ASCII
  /workspaces/cfn-model/lib/cfn-model/validator/cloudformation_validator.rb:23:in `gsub'
  /workspaces/cfn-model/lib/cfn-model/validator/cloudformation_validator.rb:23:in `json_text?'
  /workspaces/cfn-model/lib/cfn-model/validator/cloudformation_validator.rb:9:in `validate'
  /workspaces/cfn-model/lib/cfn-model/parser/cfn_parser.rb:203:in `pre_validate_model'
  /workspaces/cfn-model/lib/cfn-model/parser/cfn_parser.rb:59:in `parse_without_parameters'
  /workspaces/cfn-model/lib/cfn-model/parser/cfn_parser.rb:43:in `parse'
  /workspaces/cfn-model/bin/cfn_parse:7:in `<top (required)>'
  /usr/local/bundle/bin/cfn_parse:23:in `load'
  /usr/local/bundle/bin/cfn_parse:23:in `<top (required)>'
```

Adjusted output to be a `ParserError`:

```shell
cfn-model_dev@93c98da1d5c5:/workspaces/cfn-model$ bundle exec cfn_parse spec/test_templates/yaml/template_with_utf8_characters.yml 
======
spec/test_templates/yaml/template_with_utf8_characters.yml
======
bundler: failed to load command: cfn_parse (/usr/local/bundle/bin/cfn_parse)
ParserError: #<ArgumentError: invalid byte sequence in US-ASCII>
  /workspaces/cfn-model/lib/cfn-model/validator/cloudformation_validator.rb:17:in `rescue in validate'
  /workspaces/cfn-model/lib/cfn-model/validator/cloudformation_validator.rb:8:in `validate'
  /workspaces/cfn-model/lib/cfn-model/parser/cfn_parser.rb:203:in `pre_validate_model'
  /workspaces/cfn-model/lib/cfn-model/parser/cfn_parser.rb:59:in `parse_without_parameters'
  /workspaces/cfn-model/lib/cfn-model/parser/cfn_parser.rb:43:in `parse'
  /workspaces/cfn-model/bin/cfn_parse:7:in `<top (required)>'
  /usr/local/bundle/bin/cfn_parse:23:in `load'
  /usr/local/bundle/bin/cfn_parse:23:in `<top (required)>'
```

Finally, the read method in [cfn_parse](bin/cfn_parse) was updated to read files in as UTF-8 encoding for better compatibility.

```shell
cfn-model_dev@93c98da1d5c5:/workspaces/cfn-model$ bundle exec cfn_parse spec/test_templates/yaml/template_with_utf8_characters.yml 
======
spec/test_templates/yaml/template_with_utf8_characters.yml
======
{"R\u00F6otRole"=>#<AWS::IAM::Role:0x000055f7012055c8 @cfn_model=#<CfnModel:0x000055f7012056b8 @parameters={}, @resources={...}, @conditions={}, @globals={}, @raw_model={"AWSTemplateFormatVersion"=>"2010-09-09", "Resources"=>{"R\u00F6otRole"=>{"Type"=>{"value"=>"AWS::IAM::Role", "line"=>5}, "Properties"=>{"AssumeRolePolicyDocument"=>{"Version"=>"2012-10-17", "Statement"=>{"Effect"=>"Allow", "Principal"=>{"Service"=>["ec2.amazonaws.com"], "AWS"=>"arn:aws:iam::324320755747:root"}, "Actio\u00F1"=>["sts:AssumeRole"]}}, "Path"=>"/", "Policies"=>[{"PolicyName"=>"root", "PolicyDocument"=>{"Version"=>"2012-10-17", "Statement"=>{"Effect"=>"Allow", "Action"=>"*", "Resource"=>"*"}}}]}}}}, @line_numbers={"R\u00F6otRole"=>5}>, @policies=[{"PolicyName"=>"root", "PolicyDocument"=>{"Version"=>"2012-10-17", "Statement"=>{"Effect"=>"Allow", "Action"=>"*", "Resource"=>"*"}}}], @managedPolicyArns=[], @policy_objects=[#<Policy:0x000055f701203840 @policy_name="root", @policy_document=#<PolicyDocument:0x000055f7012037c8 @statements=[#<Statement:0x000055f701203750 @actions=["*"], @not_actions=[], @resources=["*"], @not_resources=[], @effect="Allow", @sid=nil, @condition=nil, @principal=nil, @not_principal=nil>], @version="2012-10-17">>], @resource_type="AWS::IAM::Role", @logical_resource_id="R\u00F6otRole", @metadata=nil, @assumeRolePolicyDocument={"Version"=>"2012-10-17", "Statement"=>{"Effect"=>"Allow", "Principal"=>{"Service"=>["ec2.amazonaws.com"], "AWS"=>"arn:aws:iam::324320755747:root"}, "Actio\u00F1"=>["sts:AssumeRole"]}}, @path="/", @assume_role_policy_document=#<PolicyDocument:0x000055f701203b88 @statements=[#<Statement:0x000055f701203b10 @actions=[], @not_actions=[], @resources=[], @not_resources=[], @effect="Allow", @sid=nil, @condition=nil, @principal={"Service"=>["ec2.amazonaws.com"], "AWS"=>"arn:aws:iam::324320755747:root"}, @not_principal=nil>], @version="2012-10-17">>}
```

## Testing

1. New spec tests were written to parse templates encoded with both `US-ASCII` and `UTF-8`.
2. All rspec tests pass.