### PR TITLE
#79 support partial evaluation of Sub, GetAZs, Split, Join, Base64, Join

### DIFF
--- a/lib/cfn-model/model/references.rb
+++ b/lib/cfn-model/model/references.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'cfn-model/parser/parser_error'
-require 'netaddr'
 
 ##
 # this is a placeholder for anything related to resolving references

--- a/lib/cfn-model/parser/parameter_substitution.rb
+++ b/lib/cfn-model/parser/parameter_substitution.rb
@@ -43,7 +43,8 @@ class ParameterSubstitution
       'AWS::AccountId' => '111111111111',
       'AWS::Region' => 'us-east-1',
       'AWS::StackId' => 'arn:aws:cloudformation:us-east-1:111111111111:stack/stackname/51af3dc0-da77-11e4-872e-1234567db123',
-      'AWS::StackName' => 'stackname'
+      'AWS::StackName' => 'stackname',
+      'AWS::NumberAZs' => 2
     }
     pseudo_function_defaults.each do |function_name, default_value|
       parameter = Parameter.new

--- a/publish.sh
+++ b/publish.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -ex
-export minor_version="0.4"
+export minor_version="0.5"
 set -o pipefail
 
 gem_name=cfn-model

--- a/spec/parser/cfn_parser_lambda_permission_spec.rb
+++ b/spec/parser/cfn_parser_lambda_permission_spec.rb
@@ -11,13 +11,8 @@ describe CfnParser do
       json_test_templates('lambda_permission/lambda_permission_with_non_string_principal').each do |test_template|
         cfn_model = @cfn_parser.parse IO.read(test_template)
 
-
-        actual_permissions = cfn_model.resources_by_type('AWS::Lambda::Permission')
-        actual_computed_permission = actual_permissions.find do |permission|
-          permission.principal == { 'Fn::Join' => ['-', %w(jim bob)] }
-        end
-
-        expect(actual_computed_permission).to_not be_nil
+        actual_permissions = cfn_model.resources['lambdaPermission']
+        expect(actual_permissions.principal).to eq 'jim-bob'
       end
     end
   end

--- a/spec/transforms/serverless_spec.rb
+++ b/spec/transforms/serverless_spec.rb
@@ -77,13 +77,10 @@ describe CfnModel::Transforms::Serverless do
         cloudformation_template_yml = yaml_test_template('sam/globals')
         actual_cfn_model = @cfn_parser.parse cloudformation_template_yml
 
-        expected_bucket = {
-          'Fn::Sub' => 'bucket.lambda.${Site}'
-        }
+        expected_bucket = 'bucket.lambda.${Site}'
+
         expected_endpoint_configuration = 'REGIONAL'
-        expected_key = {
-          'Fn::Sub' => 'lambda/code/${Site}/jar-with-dependencies.jar'
-        }
+        expected_key = 'lambda/code/${Site}/jar-with-dependencies.jar'
         expected_runtime = 'java8'
 
         actual_bucket = actual_cfn_model.resources['SomeFunction'].code['S3Bucket']


### PR DESCRIPTION
The References.resolve_value is the main entrypoint for evaluating a reference of any kind within the model.  Historically the ModelElement.method_missing calls upon it to attempt to resolve parameter values.  As the main entrypoint, the point is to expand beyond Parameter Refs and include the other functions.  

In so many words, any function that references a resource output or an external value will still be left alone.  Anything the can be computed based upon what is available within the template will be computed, e.g. Select [0, [1,2,3]] becomes 1.