### PR TITLE
Fix custom resource loading to ensure it is an appropriate class object

### DIFF
--- a/lib/cfn-model/parser/cfn_parser.rb
+++ b/lib/cfn-model/parser/cfn_parser.rb
@@ -281,7 +281,7 @@ class CfnParser
 
   def map_non_aws_resource_name_to_class_name(module_names)
     # this is a little hacky.  we've been ignoring Custom so more for
-    # backward compat.  for Alexa and other transformed resources just jam the whole
+    # backward compat. for Alexa and other transformed resources just jam the whole
     # thing together
     if module_names.first == 'Custom'
       first_module_index = 1
@@ -308,7 +308,8 @@ class CfnParser
     else
       custom_resource_class_name = map_non_aws_resource_name_to_class_name(module_names)
       begin
-        resource_class = Object.const_get custom_resource_class_name
+        custom_class = Object.const_get custom_resource_class_name
+        resource_class = custom_class if custom_class.is_a?(ModelElement)
       rescue NameError
         Object.const_set(custom_resource_class_name, resource_class)
       end

--- a/spec/parser/cfn_parser_custom_resource_spec.rb
+++ b/spec/parser/cfn_parser_custom_resource_spec.rb
@@ -21,5 +21,19 @@ describe CfnParser do
                                                                   })
       end
     end
+
+    it 'returns a Custom::AWS object even when it collides with known Module' do
+      yaml_test_templates('custom_resource/custom_resource_collision').each do |test_template|
+        cfn_model = @cfn_parser.parse IO.read(test_template)
+
+        custom_resources = cfn_model.resources_by_type('Custom::AWS')
+
+        expect(custom_resources.size).to eq 1
+        actual_custom_resource = custom_resources.first
+        expect(actual_custom_resource.serviceToken).to eq({
+                                                                    'Fn::GetAtt' => %w(TestLambdaFunction Arn)
+                                                                  })
+      end
+    end
   end
 end

--- a/spec/test_templates/yaml/custom_resource/custom_resource_collision.yml
+++ b/spec/test_templates/yaml/custom_resource/custom_resource_collision.yml
@@ -1,0 +1,85 @@
+Parameters:
+  Base:
+    Type: "String"
+    Default: "10"
+
+  CustomResourceId:
+    Type: "String"
+    Default: "SomeCustomResourceId"
+
+
+Resources:
+  TestCustomResource:
+    Type: "Custom::AWS"
+    Properties:
+      ServiceToken: !GetAtt "TestLambdaFunction.Arn"
+      Base: !Ref Base
+      Id: !Ref CustomResourceId
+      actions-csv: some_value
+
+  TestLambdaFunction:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Handler: "index.handler"
+      Role: !GetAtt "TestLambdaExecutionRole.Arn"
+      Code:
+        ZipFile: |
+          var response = require('cfn-response');
+          exports.handler = function(event, context) {
+              console.log('Received event:');
+              console.log(JSON.stringify(event));
+              var base = event.ResourceProperties.Base;
+              var customId = event.ResourceProperties.Id;
+              var outputData = {};
+              try {
+                 if(event.RequestType != 'Delete')
+                     outputData.Result = base*5;
+                 if(event.RequestType == 'Delete' || outputData.Result == parseInt(outputData.Result, 10))
+                     response.send(event, context, response.SUCCESS, outputData, customId);
+                 else
+                     response.send(event, context, response.FAILED, {}, customId);
+              } catch (e) {
+                 console.error(e);
+                 response.send(event, context, response.FAILED, { 'error': e }, customId);
+                 return
+              }
+          }
+      Timeout: "10"
+      MemorySize: "256"
+      Runtime: "nodejs4.3"
+
+  TestLambdaExecutionRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Path: "/"
+      Policies:
+        - PolicyName: "cwlogs"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action: "logs:CreateLogGroup"
+                Resource: !Join [":", ["arn:aws:logs", !Ref "AWS::Region", !Ref "AWS::AccountId", "*" ]]
+
+
+              - Effect: "Allow"
+                Action:
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+
+                Resource:
+                  - !Join [":", ["arn:aws:logs", !Ref "AWS::Region", !Ref "AWS::AccountId", "log-group", "/aws/lambda/*", "*" ]]
+
+
+Outputs:
+  Result:
+    Value: !GetAtt "TestCustomResource.Result"


### PR DESCRIPTION
If loading a custom resource in a template and the name matched an existing Ruby object constant, it would try to use that constant as a class for the resource. This causes issues if that isn't a `ModelElement`, as the initialization will fail.

In particular, this exists with custom resources generated by the CDK, as they are typed `Custom:AWS` which led to this trying to instantiate the `AWS` module, which is not possible.

See CDK default here: https://github.com/aws/aws-cdk/blob/v1.67.0/packages/@aws-cdk/custom-resources/lib/aws-custom-resource/aws-custom-resource.ts#L377

Resolves reported issue in cfn_nag: https://github.com/stelligent/cfn_nag/issues/481