### PR TITLE
Pass-through cfn_nag metadata to Serverless transformed resources

### DIFF
--- a/lib/cfn-model/transforms/serverless.rb
+++ b/lib/cfn-model/transforms/serverless.rb
@@ -128,6 +128,13 @@ class CfnModel
 
         transform_function_events(cfn_hash, serverless_function, resource_name, with_line_numbers) if \
           serverless_function['Properties']['Events']
+
+        # Handle passing along cfn-nag specific metadata. SAM itself does not support metadata during transformation.
+        # https://github.com/aws/serverless-application-model/issues/264
+        if serverless_function.key?('Metadata') && serverless_function['Metadata'].key?('cfn_nag')
+          cfn_hash['Resources'][resource_name]['Metadata'] = serverless_function['Metadata']
+          cfn_hash['Resources'][resource_name + 'Role']['Metadata'] = serverless_function['Metadata']
+        end
       end
 
       def lambda_service_can_assume_role

--- a/spec/test_templates/yaml/sam/valid_metadata_lambda_fn.yml
+++ b/spec/test_templates/yaml/sam/valid_metadata_lambda_fn.yml
@@ -1,0 +1,16 @@
+---
+# Example from
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-serverless.html
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  MyServerlessFunctionLogicalID:
+    Type: AWS::Serverless::Function
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W58
+            reason: I know what I am doing
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs12.x
+      CodeUri: 's3://testBucket/mySourceCode.zip'

--- a/spec/transforms/serverless_spec.rb
+++ b/spec/transforms/serverless_spec.rb
@@ -60,6 +60,9 @@ describe CfnModel::Transforms::Serverless do
       ).to(
         eq 'AWS::Lambda::Function'
       )
+      expect(
+        actual_cfn_model.raw_model['Resources']['MyServerlessFunctionLogicalID'].key?('Metadata')
+      ).to be false
     end
     it 'Ensures "FunctionNameRole" AWS::IAM::Role' do
       cloudformation_template_yml = \
@@ -95,6 +98,20 @@ describe CfnModel::Transforms::Serverless do
         expect(global_endpoint_configuration).to eq expected_endpoint_configuration
         expect(global_runtime).to eq expected_runtime
       end
+    end
+  end
+
+  context 'Template with serverless transform and metadata' do
+    it 'Adds metadata to transformed resources' do
+      cloudformation_template_yml = \
+        yaml_test_template('sam/valid_metadata_lambda_fn')
+      actual_cfn_model = @cfn_parser.parse cloudformation_template_yml
+      expect(
+        actual_cfn_model.raw_model['Resources']['MyServerlessFunctionLogicalID'].key?('Metadata')
+      ).to be true
+      expect(
+        actual_cfn_model.raw_model['Resources']['MyServerlessFunctionLogicalIDRole'].key?('Metadata')
+      ).to be true
     end
   end
 


### PR DESCRIPTION
When the model transforms SAM resources, metadata is not included in the transform which prevents users of cfn_nag from being able to ignore rules on those transformed resources.

Since SAM does not support metadata by default (https://github.com/aws/serverless-application-model/issues/264), we only copy over metadata if cfn_nag specific contents are included.

Resolves issue reported in cfn_nag: https://github.com/stelligent/cfn_nag/issues/422