### PR TITLE
Allow running on Ruby 3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
   specs:
     ast (2.4.0)
     diff-lcs (1.3)
-    docile (1.3.2)
+    docile (1.3.5)
     jaro_winkler (1.5.4)
     kwalify (0.7.2)
     parallel (1.19.1)
@@ -39,7 +39,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
-    simplecov (0.20.0)
+    simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
@@ -57,4 +57,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,10 +39,12 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
-    simplecov (0.18.1)
+    simplecov (0.20.0)
       docile (~> 1.1)
-      simplecov-html (~> 0.11.0)
-    simplecov-html (0.11.0)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.2)
     unicode-display_width (1.6.1)
 
 PLATFORMS

--- a/cfn-model.gemspec
+++ b/cfn-model.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.require_paths << 'lib'
 
-  s.required_ruby_version = '~> 2.2'
+  s.required_ruby_version = '>= 2.2.0'
 
   s.add_development_dependency 'rubocop'
 

--- a/cfn-model.gemspec
+++ b/cfn-model.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.require_paths << 'lib'
 
-  s.required_ruby_version = '>= 2.2.0'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.add_development_dependency 'rubocop'
 

--- a/parse_samples.sh
+++ b/parse_samples.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -l
 
-rvm use 2.2.1
+rvm use 2.5.8
 rvm --force gemset delete cfn_model
 rvm gemset use cfn_model --create
 

--- a/publish.sh
+++ b/publish.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -ex
-export minor_version="0.5"
+export minor_version="0.6"
 set -o pipefail
 
 gem_name=cfn-model


### PR DESCRIPTION
### Context

This gem currently allows Running on Ruby `~> 2.2` (expanded: `>= 2.2.0, < 3`). This makes it unavailable for use on the recently released Ruby 3.0.

### Change

Allow running the gem on Ruby 3.0 by removing the upper bound.

Also update the `simplecov` development dependency to a version compatible with Ruby 3.0.

### Considerations

The RSpec test suite passes for me on Ruby 3.0.
