### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/cfn-model.gemspec
+++ b/cfn-model.gemspec
@@ -9,6 +9,13 @@ Gem::Specification.new do |s|
   s.summary       = 'cfn-model'
   s.description   = 'An object model for CloudFormation templates'
   s.homepage      = 'https://github.com/stelligent/cfn-model'
+  s.metadata      = {
+    'bug_tracker_uri'   => "#{s.homepage}/issues",
+    'changelog_uri'     => "#{s.homepage}/releases",
+    'documentation_uri' => "https://www.rubydoc.info/gems/#{s.name}/#{s.version}",
+    'homepage_uri'      => s.homepage,
+    'source_code_uri'   => "#{s.homepage}/tree/v#{s.version}",
+  }
   s.files         = FileList[ 'lib/**/*.rb', 'lib/**/*.yml', 'lib/**/*.erb']
 
   s.require_paths << 'lib'


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `homepage_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/cfn-model), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.