### PR TITLE
Allow psych v4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     cfn-model (9.9.9)
       kwalify (= 0.7.2)
-      psych (~> 3)
+      psych (>= 3.1, < 5)
 
 GEM
   remote: https://rubygems.org/
@@ -16,7 +16,8 @@ GEM
     parallel (1.19.1)
     parser (2.7.0.2)
       ast (~> 2.4.0)
-    psych (3.1.0)
+    psych (4.0.3)
+      stringio
     rainbow (3.0.0)
     rake (13.0.3)
     rspec (3.9.0)
@@ -46,6 +47,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.2)
+    stringio (3.0.1)
     unicode-display_width (1.6.1)
 
 PLATFORMS

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ upon which static analysis can be conducted.
 The `CfnModel` is a container for other object that have been parsed, wrapped and potentially linked to
 other wrapped objects.
 
-The raw Hash output of `YAML.load` is also available from `CfnModel`.
+The raw Hash output of `YAML.safe_load` is also available from `CfnModel`.
 
     require 'cfn-model'
         

--- a/cfn-model.gemspec
+++ b/cfn-model.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('simplecov', '~> 0.11')
 
   s.add_runtime_dependency('kwalify', '0.7.2')
-  s.add_runtime_dependency('psych', '~> 3')
+  s.add_runtime_dependency('psych', '>= 3.1', '< 5')
 end

--- a/lib/cfn-model/model/cfn_model.rb
+++ b/lib/cfn-model/model/cfn_model.rb
@@ -6,7 +6,7 @@ class CfnModel
   attr_reader :resources, :parameters, :line_numbers, :conditions, :globals, :mappings, :element_types
 
   ##
-  # if you really want it, here it is - the raw Hash from YAML.load.  you'll have to mess with structural nits of
+  # if you really want it, here it is - the raw Hash from YAML.safe_load.  you'll have to mess with structural nits of
   # CloudFormation and deal with variations between yaml/json refs and all that
   #
   attr_accessor :raw_model

--- a/lib/cfn-model/parser/cfn_parser.rb
+++ b/lib/cfn-model/parser/cfn_parser.rb
@@ -65,7 +65,7 @@ class CfnParser
       if with_line_numbers
         parse_with_line_numbers(cloudformation_yml)
       else
-        YAML.load cloudformation_yml
+        YAML.safe_load cloudformation_yml, permitted_classes: [Date]
       end
 
     # Transform raw resources in template as performed by

--- a/lib/cfn-model/validator/cloudformation_validator.rb
+++ b/lib/cfn-model/validator/cloudformation_validator.rb
@@ -12,7 +12,7 @@ class CloudFormationValidator
 
     schema = SchemaGenerator.new.generate cloudformation_string
     validator = Kwalify::Validator.new(schema)
-    validator.validate(YAML.load(cloudformation_string))
+    validator.validate(YAML.safe_load(cloudformation_string, permitted_classes: [Date]))
   rescue ArgumentError, IOError, NameError => e
     raise ParserError, e.inspect
   end

--- a/lib/cfn-model/validator/resource_type_validator.rb
+++ b/lib/cfn-model/validator/resource_type_validator.rb
@@ -5,7 +5,7 @@ require 'cfn-model/parser/parser_error'
 class ResourceTypeValidator
 
   def self.validate(cloudformation_yml)
-    hash = YAML.load cloudformation_yml
+    hash = YAML.safe_load cloudformation_yml, permitted_classes: [Date]
     if hash == false || hash.nil?
       raise ParserError.new 'yml empty'
     end

--- a/lib/cfn-model/validator/schema_generator.rb
+++ b/lib/cfn-model/validator/schema_generator.rb
@@ -19,7 +19,7 @@ class SchemaGenerator
     parameters_schema = generate_schema_for_parameter_keys cloudformation_hash
     resources_schema = generate_schema_for_resource_keys cloudformation_hash
 
-    main_schema = YAML.load IO.read(schema_file('schema.yml.erb'))
+    main_schema = YAML.safe_load IO.read(schema_file('schema.yml.erb'))
     if parameters_schema.empty?
       main_schema['mapping'].delete 'Parameters'
     else
@@ -82,7 +82,7 @@ class SchemaGenerator
     if !File.exist? schema_file_path
       nil
     else
-      YAML.load IO.read(schema_file_path)
+      YAML.safe_load IO.read(schema_file_path)
     end
   end
 end

--- a/spec/validator/reference_validator_spec.rb
+++ b/spec/validator/reference_validator_spec.rb
@@ -23,7 +23,7 @@ Resources:
       JimBob: !Ref someResource
 END
 
-      unresolved_references = ReferenceValidator.new.unresolved_references YAML.load(cfn_yaml_with_missing_ref)
+      unresolved_references = ReferenceValidator.new.unresolved_references YAML.safe_load(cfn_yaml_with_missing_ref)
       expect(unresolved_references).to eq Set.new(%w(dino))
     end
   end
@@ -48,7 +48,7 @@ Resources:
       JimBob: !Ref someResource
 END
 
-      unresolved_references = ReferenceValidator.new.unresolved_references YAML.load(cfn_yaml_with_missing_ref)
+      unresolved_references = ReferenceValidator.new.unresolved_references YAML.safe_load(cfn_yaml_with_missing_ref)
       expect(unresolved_references).to eq Set.new(%w(dino))
     end
   end
@@ -72,7 +72,7 @@ Resources:
 END
 
       expect {
-        _ = ReferenceValidator.new.unresolved_references YAML.load(cfn_yaml_with_missing_ref)
+        _ = ReferenceValidator.new.unresolved_references YAML.safe_load(cfn_yaml_with_missing_ref)
       }.to raise_error(ParserError, 'Ref target must be string literal: {"Ref"=>{"Fn::GetAtt"=>["someResource", "Fred"]}}')
     end
   end
@@ -90,7 +90,7 @@ Resources:
       Barney: !Ref AWS::Region
 END
 
-      unresolved_references = ReferenceValidator.new.unresolved_references YAML.load(cfn_yaml_with_missing_ref)
+      unresolved_references = ReferenceValidator.new.unresolved_references YAML.safe_load(cfn_yaml_with_missing_ref)
       expect(unresolved_references).to eq Set.new([])
     end
   end
@@ -115,7 +115,7 @@ Resources:
       JimBob: !Ref someResource
 END
 
-      unresolved_references = ReferenceValidator.new.unresolved_references YAML.load(cfn_yaml_with_missing_ref)
+      unresolved_references = ReferenceValidator.new.unresolved_references YAML.safe_load(cfn_yaml_with_missing_ref)
       expect(unresolved_references).to eq Set.new(%w(dino2))
     end
   end
@@ -144,7 +144,7 @@ Resources:
       JimBob: !Ref someResource
 END
 
-      unresolved_references = ReferenceValidator.new.unresolved_references YAML.load(cfn_yaml_with_missing_ref)
+      unresolved_references = ReferenceValidator.new.unresolved_references YAML.safe_load(cfn_yaml_with_missing_ref)
       expect(unresolved_references).to eq Set.new(%w(dino2))
     end
   end
@@ -170,7 +170,7 @@ Resources:
       Ricky: !Ref someResource.Version
 END
 
-      unresolved_references = ReferenceValidator.new.unresolved_references YAML.load(cfn_yaml_with_pseudo_refs)
+      unresolved_references = ReferenceValidator.new.unresolved_references YAML.safe_load(cfn_yaml_with_pseudo_refs)
       expect(unresolved_references).to eq Set.new(%w())
     end
   end
@@ -196,7 +196,7 @@ Resources:
       Ricky: !Ref bogus.Version
 END
 
-      unresolved_references = ReferenceValidator.new.unresolved_references YAML.load(cfn_yaml_with_pseudo_refs)
+      unresolved_references = ReferenceValidator.new.unresolved_references YAML.safe_load(cfn_yaml_with_pseudo_refs)
       expect(unresolved_references).to eq Set.new(%w(bogus.Version))
     end
   end


### PR DESCRIPTION
### Context

Version 4 of the psych gem has been released and is provided with Ruby 3.1. Let's make cfn-model compatible with this new major version for psych!

### Change

Relax the gem dependency constraints so psych V3 or V4 can be used.

In psych v4, the `YAML.load` method has been updated to provide a similar interface and semantics to `YAML.safe_load`. Refactor the code to use `YAML.safe_load` for a consistent behaviour between psych V3 and V4.

### Considerations

Psych will automatically convert strings that look like dates to Ruby `Date` objects. We need to permit this class when loading CloudFormation YAML.

The `permitted_classes` keyword argument for `YAML.safe_load` was [introduced in psych v3.1.0](https://github.com/ruby/psych/compare/v3.0.2..v3.1.0#diff-659eac8589abc82c9a0ab3699e4e4be4774d9c09c6c9934af5d9dae0d264439cR328). So this is now the minimum compatible version of psych.