### PR TITLE
Handle CFN template values being represented as symbols

### DIFF
--- a/lib/cfn-model/parser/cfn_parser.rb
+++ b/lib/cfn-model/parser/cfn_parser.rb
@@ -65,7 +65,7 @@ class CfnParser
       if with_line_numbers
         parse_with_line_numbers(cloudformation_yml)
       else
-        YAML.safe_load cloudformation_yml, permitted_classes: [Date]
+        YAML.safe_load cloudformation_yml, permitted_classes: [Date, Symbol]
       end
 
     # Transform raw resources in template as performed by

--- a/lib/cfn-model/validator/cloudformation_validator.rb
+++ b/lib/cfn-model/validator/cloudformation_validator.rb
@@ -12,7 +12,7 @@ class CloudFormationValidator
 
     schema = SchemaGenerator.new.generate cloudformation_string
     validator = Kwalify::Validator.new(schema)
-    validator.validate(YAML.safe_load(cloudformation_string, permitted_classes: [Date]))
+    validator.validate(YAML.safe_load(cloudformation_string, permitted_classes: [Date, Symbol]))
   rescue ArgumentError, IOError, NameError => e
     raise ParserError, e.inspect
   end

--- a/lib/cfn-model/validator/resource_type_validator.rb
+++ b/lib/cfn-model/validator/resource_type_validator.rb
@@ -5,7 +5,7 @@ require 'cfn-model/parser/parser_error'
 class ResourceTypeValidator
 
   def self.validate(cloudformation_yml)
-    hash = YAML.safe_load cloudformation_yml, permitted_classes: [Date]
+    hash = YAML.safe_load cloudformation_yml, permitted_classes: [Date, Symbol]
     if hash == false || hash.nil?
       raise ParserError.new 'yml empty'
     end

--- a/spec/parser/cfn_parser_spec.rb
+++ b/spec/parser/cfn_parser_spec.rb
@@ -271,6 +271,9 @@ Parameters:
     Type: String
     NoEcho: true
     Default: none
+  TestIPV6:
+    Type: String
+    Default: ::/0
 Conditions:
   IsNone: !Or
     - !Equals

--- a/spec/validator/cloudformation_validator_spec.rb
+++ b/spec/validator/cloudformation_validator_spec.rb
@@ -176,5 +176,23 @@ TEMPLATE
 
       expect(CloudFormationValidator.new.validate(valid_yaml)).to eq []
     end
+
+    it 'does not raise an error when template is YAML with date and symbol values' do
+      valid_yaml = <<~TEMPLATE
+        ---
+        AWSTemplateFormatVersion: 2010-09-09
+        Resources:
+          SecurityGroupIngress:
+            Type: AWS::EC2::SecurityGroupIngress
+            Properties:
+              GroupId: sg-12341234
+              CidrIpv6: ::/0
+              FromPort: 22
+              ToPort: 22
+              IpProtocol: tcp
+      TEMPLATE
+
+      expect(CloudFormationValidator.new.validate(valid_yaml)).to eq []
+    end
   end
 end

--- a/spec/validator/resource_type_validator_spec.rb
+++ b/spec/validator/resource_type_validator_spec.rb
@@ -123,4 +123,42 @@ END
       expect(actual_hash).to eq expected_hash
     end
   end
+
+  context 'given a template with date and symbol values' do
+    let(:template) { <<~TEMPLATE }
+      ---      
+      AWSTemplateFormatVersion: 2010-09-09
+      Resources:
+        SecurityGroupIngress:
+          Type: AWS::EC2::SecurityGroupIngress
+          Properties:
+            GroupId: sg-12341234
+            CidrIpv6: ::/0
+            FromPort: 22
+            ToPort: 22
+            IpProtocol: tcp
+    TEMPLATE
+
+    it 'successfully returns the Hash of the parsed document' do
+      parsed_template = ResourceTypeValidator.validate(template)
+
+      expect(parsed_template).to eq(
+        {
+          'AWSTemplateFormatVersion' => Date.new(2010, 9, 9),
+          'Resources' => {
+            'SecurityGroupIngress' => {
+              'Type' => 'AWS::EC2::SecurityGroupIngress',
+              'Properties' => {
+                'GroupId' => 'sg-12341234',
+                'CidrIpv6' => :':/0',
+                'FromPort' => 22,
+                'ToPort' => 22,
+                'IpProtocol' => 'tcp'
+              }
+            }
+          }
+        }
+      )
+    end
+  end
 end


### PR DESCRIPTION
### Context

Psych will interpret unquoted YAML values starting with a `:` character as a Ruby symbol. `Symbol` isn't listed as a permitted class when loading CloudFormation templates, so an error is raised.

This is an issue since YAML safe loading was introduced #98.

### Change

Avoid raising an error in this scenario, add `Symbol` to the list of permitted classes when loading CloudFormation YAML templates.